### PR TITLE
Trim diffed HTML and improve serializer test.

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -1,7 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should beautify HTML 1`] = `
-
 <div id="header">
   <a id="logo"
      href="/"
@@ -209,7 +208,6 @@ exports[`should beautify HTML 1`] = `
     </li>
   </ul>
 </div>
-
 `;
 
 exports[`should only act on HTML strings 1`] = `"Some text without any tags."`;

--- a/index.js
+++ b/index.js
@@ -2,9 +2,14 @@ var toDiffableHtml = require('diffable-html');
 
 module.exports = {
   test(object) {
-    return typeof object === 'string' && object.trim()[0] === '<';
+    if (typeof object !== 'string') {
+      return false;
+    }
+
+    const trimmed = object.trim();
+    return trimmed.length > 2 && trimmed[0] === '<' && trimmed[trimmed.length - 1] === '>';
   },
   print(val) {
-    return toDiffableHtml(val);
+    return toDiffableHtml(val).trim();
   },
 };


### PR DESCRIPTION
This PR resolves two issues:
1) Currently, the snapshot has an extra newline on the top and bottom. This especially looks ugly with (new and improved!) inline snapshots. I resolve it in this PR with a simple `trim()`.
2) Also check to be sure any possible HTML string ends with `>`.